### PR TITLE
Add ASCII Mandelbrot generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # SomethingAwesome
 
-This is a new project for something awesome! 
+This project contains a simple command line tool that renders the Mandelbrot set as ASCII art.
+
+## Usage
+
+Run the script using Python 3. You can specify the output width, height, and maximum iterations via command line flags.
+
+```bash
+python3 mandelbrot.py --width 120 --height 60 --max-iter 50
+```
+
+The default parameters (80x40, 30 iterations) produce a decent preview of the fractal directly in your terminal.
+
+Enjoy exploring fractals in your console!

--- a/mandelbrot.py
+++ b/mandelbrot.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Simple ASCII Mandelbrot set generator."""
+
+
+def mandelbrot(width=80, height=40, max_iter=30,
+               x_min=-2.0, x_max=1.0, y_min=-1.0, y_max=1.0):
+    chars = " .'`^\",:;Il!i><~+_-?][}{1)(|\\/*tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$"
+    w_range = x_max - x_min
+    h_range = y_max - y_min
+    output = []
+    for y in range(height):
+        imaginary = y_min + (y / height) * h_range
+        row = []
+        for x in range(width):
+            real = x_min + (x / width) * w_range
+            c = complex(real, imaginary)
+            z = 0j
+            iteration = 0
+            while abs(z) <= 2.0 and iteration < max_iter:
+                z = z * z + c
+                iteration += 1
+            index = int(iteration / max_iter * (len(chars) - 1))
+            row.append(chars[index])
+        output.append("".join(row))
+    return "\n".join(output)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="ASCII Mandelbrot generator")
+    parser.add_argument('--width', type=int, default=80,
+                        help='Output width in characters')
+    parser.add_argument('--height', type=int, default=40,
+                        help='Output height in characters')
+    parser.add_argument('--max-iter', type=int, default=30,
+                        help='Maximum number of iterations')
+    args = parser.parse_args()
+    print(mandelbrot(args.width, args.height, args.max_iter))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a small CLI program that prints the Mandelbrot set in ASCII
- document usage in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e1016feb8832caf9a626b23d91f93